### PR TITLE
Ignore lib directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ typings/
 # dotenv environment variables file
 .env
 
+lib


### PR DESCRIPTION
Added `lib` directory to `.gitignore`, which is specified as a destination of TypeScript compilation.