### PR TITLE
Add remove and removeC functions to dictionary module

### DIFF
--- a/src/dictionary/index.ts
+++ b/src/dictionary/index.ts
@@ -7,5 +7,6 @@ export { insert, insertC } from './insert';
 export { keys } from './keys';
 export { map, mapC } from './map';
 export { mapWithKey, mapWithKeyC } from './mapWithKey';
+export { remove, removeC } from './remove';
 export { singleton, singletonC } from './singleton';
 export { values } from './values';

--- a/src/dictionary/remove.ts
+++ b/src/dictionary/remove.ts
@@ -1,0 +1,16 @@
+import { Dictionary } from './Dictionary';
+import { empty } from './empty';
+
+export function remove<T>(key: string, dict: Dictionary<T>): Dictionary<T> {
+    const newDict = Object.assign(empty(), dict);
+
+    delete newDict[key];
+
+    return newDict;
+}
+
+export function removeC<T>(key: string): (dict: Dictionary<T>) => Dictionary<T> {
+    return function (dict: Dictionary<T>): Dictionary<T> {
+        return remove(key, dict);
+    }
+}

--- a/test/dictionary/remove.ts
+++ b/test/dictionary/remove.ts
@@ -1,0 +1,25 @@
+import 'mocha';
+import * as assert from 'power-assert';
+import { remove, removeC } from '../../src/dictionary';
+
+const dict = { foo: 0, bar: 42 };
+
+describe('Dictionary.remove()', () => {
+    it('should remove the value associated with the given key', () => {
+        assert.deepEqual(remove('foo', dict), { bar: 42 })
+    });
+
+    it('should do nothing on a dictionary without the given key', () => {
+        assert.deepEqual(remove('baz', dict), dict);
+    });
+});
+
+describe('Dictionary.removeC()', () => {
+    it('should remove the value associated with the given key', () => {
+        assert.deepEqual(removeC('foo')(dict), { bar: 42 })
+    });
+
+    it('should do nothing on a dictionary without the given key', () => {
+        assert.deepEqual(removeC('baz')(dict), dict);
+    });
+});


### PR DESCRIPTION
Added `remove` function in `dictionary` module, which returns a new dictionary without the given key, along its curried version (`removeC`).