### PR TITLE
Add version badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,5 @@
 
 The essential toolbox for functional programming in TypeScript
 
+[![npm version](https://badge.fury.io/js/jazz-func.svg)](https://badge.fury.io/js/jazz-func)
 [![CircleCI](https://circleci.com/gh/herp-inc/jazz-func/tree/master.svg?style=svg&circle-token=11a990edb7a6c8c031343bc9753e2f6fa566434d)](https://circleci.com/gh/herp-inc/jazz-func/tree/master)


### PR DESCRIPTION
Added a [version badge](http://badge.fury.io/) in README.

Looks like this 😉 
[![https://gyazo.com/2d3d416cc55e023f412168f9ebab21b1](https://gyazo.com/2d3d416cc55e023f412168f9ebab21b1/raw)](https://gyazo.com/2d3d416cc55e023f412168f9ebab21b1)