### PR TITLE
Add Dictionary.unionLeft() and Dictionary.unionRight()

### DIFF
--- a/src/dictionary/index.ts
+++ b/src/dictionary/index.ts
@@ -9,4 +9,6 @@ export { map, mapC } from './map';
 export { mapWithKey, mapWithKeyC } from './mapWithKey';
 export { remove, removeC } from './remove';
 export { singleton, singletonC } from './singleton';
+export { unionLeft, unionLeftC } from './unionLeft';
+export { unionRight, unionRightC } from './unionRight';
 export { values } from './values';

--- a/src/dictionary/unionLeft.ts
+++ b/src/dictionary/unionLeft.ts
@@ -1,0 +1,17 @@
+import { Dictionary } from './Dictionary';
+import { empty } from './empty';
+
+export function unionLeft<T>(left: Dictionary<T>, right: Dictionary<T>): Dictionary<T> {
+    const newDict: Dictionary<T> = empty<T>();
+
+    for (const key in right) newDict[key] = right[key];
+    for (const key in left) newDict[key] = left[key];
+
+    return newDict;
+}
+
+export function unionLeftC<T>(left: Dictionary<T>): (right: Dictionary<T>) => Dictionary<T> {
+    return function (right: Dictionary<T>): Dictionary<T> {
+        return unionLeft(left, right);
+    }
+}

--- a/src/dictionary/unionRight.ts
+++ b/src/dictionary/unionRight.ts
@@ -1,0 +1,17 @@
+import { Dictionary } from './Dictionary';
+import { empty } from './empty';
+
+export function unionRight<T>(left: Dictionary<T>, right: Dictionary<T>): Dictionary<T> {
+    const newDict: Dictionary<T> = empty<T>();
+
+    for (const key in left) newDict[key] = left[key];
+    for (const key in right) newDict[key] = right[key];
+
+    return newDict;
+}
+
+export function unionRightC<T>(left: Dictionary<T>): (right: Dictionary<T>) => Dictionary<T> {
+    return function (right: Dictionary<T>): Dictionary<T> {
+        return unionRight(left, right);
+    }
+}

--- a/test/dictionary/unionLeft.ts
+++ b/test/dictionary/unionLeft.ts
@@ -1,0 +1,41 @@
+import 'mocha';
+import * as assert from 'power-assert';
+import { unionLeft, unionLeftC } from '../../src/dictionary';
+
+describe('Dictionary.unionLeft()', () => {
+    it('should return the union of two dictionaries', () => {
+        assert.deepEqual(unionLeft({ foo: 0, bar: 1 }, { baz: 2, qux: 3 }), {
+            foo: 0,
+            bar: 1,
+            baz: 2,
+            qux: 3
+        });
+    });
+
+    it('should be left-biased', () => {
+        assert.deepEqual(unionLeft({ foo: 0, bar: 1 }, { foo: 42, baz: 2 }), {
+            foo: 0,
+            bar: 1,
+            baz: 2
+        });
+    });
+});
+
+describe('Dictionary.unionLeftC()', () => {
+    it('should return the union of two dictionaries', () => {
+        assert.deepEqual(unionLeftC({ foo: 0, bar: 1 })({ baz: 2, qux: 3 }), {
+            foo: 0,
+            bar: 1,
+            baz: 2,
+            qux: 3
+        });
+    });
+
+    it('should be left-biased', () => {
+        assert.deepEqual(unionLeftC({ foo: 0, bar: 1 })({ foo: 42, baz: 2 }), {
+            foo: 0,
+            bar: 1,
+            baz: 2
+        });
+    });
+});

--- a/test/dictionary/unionRight.ts
+++ b/test/dictionary/unionRight.ts
@@ -1,0 +1,41 @@
+import 'mocha';
+import * as assert from 'power-assert';
+import { unionRight, unionRightC } from '../../src/dictionary';
+
+describe('Dictionary.unionRight()', () => {
+    it('should return the union of two dictionaries', () => {
+        assert.deepEqual(unionRight({ foo: 0, bar: 1 }, { baz: 2, qux: 3 }), {
+            foo: 0,
+            bar: 1,
+            baz: 2,
+            qux: 3
+        });
+    });
+
+    it('should be right-biased', () => {
+        assert.deepEqual(unionRight({ foo: 0, bar: 1 }, { foo: 42, baz: 2 }), {
+            foo: 42,
+            bar: 1,
+            baz: 2
+        });
+    });
+});
+
+describe('Dictionary.unionRightC()', () => {
+    it('should return the union of two dictionaries', () => {
+        assert.deepEqual(unionRightC({ foo: 0, bar: 1 })({ baz: 2, qux: 3 }), {
+            foo: 0,
+            bar: 1,
+            baz: 2,
+            qux: 3
+        });
+    });
+
+    it('should be right-biased', () => {
+        assert.deepEqual(unionRightC({ foo: 0, bar: 1 })({ foo: 42, baz: 2 }), {
+            foo: 42,
+            bar: 1,
+            baz: 2
+        });
+    });
+});


### PR DESCRIPTION
Added the following functions in `Dictionary` module, which returns the (left- or right-biased) union of the given two dictionaries:

- `unionLeft()`
- `unionLeftC()`
- `unionRight()`
- `unionRightC()`