### PR TITLE
Add Dictionary.lookup() function

### DIFF
--- a/src/dictionary/index.ts
+++ b/src/dictionary/index.ts
@@ -5,6 +5,7 @@ export { filter, filterC } from './filter';
 export { fromArray } from './fromArray';
 export { insert, insertC } from './insert';
 export { keys } from './keys';
+export { lookup, lookupC } from './lookup';
 export { map, mapC } from './map';
 export { mapWithKey, mapWithKeyC } from './mapWithKey';
 export { remove, removeC } from './remove';

--- a/src/dictionary/lookup.ts
+++ b/src/dictionary/lookup.ts
@@ -1,0 +1,12 @@
+import { Dictionary } from './Dictionary';
+import { Nullable } from '../nullable/Nullable';
+
+export function lookup<T>(key: string, dict: Dictionary<T>): Nullable<T> {
+    return Object.prototype.hasOwnProperty.call(dict, key) ? dict[key] : null;
+}
+
+export function lookupC<T>(key: string): (dict: Dictionary<T>) => Nullable<T> {
+    return function (dict: Dictionary<T>): Nullable<T> {
+        return lookup(key, dict);
+    }
+}

--- a/test/dictionary/lookup.ts
+++ b/test/dictionary/lookup.ts
@@ -1,0 +1,23 @@
+import 'mocha';
+import * as assert from 'power-assert';
+import { lookup, lookupC } from '../../src/dictionary';
+
+describe('Dictionary.lookup()', () => {
+    it('should look up the value associated to the given key', () => {
+        assert.equal(lookup('foo', { foo: 42, bar: 0 }), 42);
+    });
+
+    it('should return null when the key is not found', () => {
+        assert.equal(lookup('foo', { bar: 0 }), null);
+    });
+});
+
+describe('Dictionary.lookupC()', () => {
+    it('should look up the value associated to the given key', () => {
+        assert.equal(lookupC('foo')({ foo: 42, bar: 0 }), 42);
+    });
+
+    it('should return null when the key is not found', () => {
+        assert.equal(lookupC('foo')({ bar: 0 }), null);
+    });
+});


### PR DESCRIPTION
Added `lookup()` function in `Dictionary` module, which returns the value associated to the given key if exists, otherwise `null`.