### PR TITLE
Add getProp, setProp, and modifyProp functions for Struct

### DIFF
--- a/src/struct/getProp.ts
+++ b/src/struct/getProp.ts
@@ -1,0 +1,9 @@
+export function getProp<T extends object, K extends keyof T>(key: K, struct: T): T[K] {
+    return struct[key];
+}
+
+export function getPropC<T extends object, K extends keyof T>(key: K): (struct: T) => T[K] {
+    return function (struct: T): T[K] {
+        return getProp(key, struct);
+    }
+}

--- a/src/struct/index.ts
+++ b/src/struct/index.ts
@@ -1,0 +1,3 @@
+export { getProp, getPropC } from './getProp';
+export { modifyProp, modifyPropC } from './modifyProp';
+export { setProp, setPropC } from './setProp';

--- a/src/struct/modifyProp.ts
+++ b/src/struct/modifyProp.ts
@@ -1,0 +1,14 @@
+export function modifyProp<T extends object, K extends keyof T>(key: K, f: (old: T[K]) => T[K], struct: T): T {
+    const newStruct = Object.assign({}, struct);
+    newStruct[key] = f(struct[key]);
+
+    return newStruct;
+}
+
+export function modifyPropC<T extends object, K extends keyof T = keyof T>(key: K): (f: (old: T[K]) => T[K]) => (struct: T) => T {
+    return function (f: (old: T[K]) => T[K]): (struct: T) => T {
+        return function (struct: T): T {
+            return modifyProp(key, f, struct);
+        }
+    }
+}

--- a/src/struct/setProp.ts
+++ b/src/struct/setProp.ts
@@ -1,0 +1,14 @@
+export function setProp<T extends object, K extends keyof T>(key: K, value: T[K], struct: T): T {
+    const newStruct = Object.assign({}, struct);
+    newStruct[key] = value;
+
+    return newStruct;
+}
+
+export function setPropC<T extends object, K extends keyof T>(key: K): (value: T[K]) => (struct: T) => T {
+    return function (value: T[K]): (struct: T) => T {
+        return function (struct: T): T {
+            return setProp(key, value, struct);
+        }
+    }
+}

--- a/test/struct/getProp.ts
+++ b/test/struct/getProp.ts
@@ -1,0 +1,22 @@
+import 'mocha';
+import * as assert from 'power-assert';
+import { getProp, getPropC } from '../../src/struct';
+
+type Point = {
+    x: number;
+    y: number;
+}
+
+const origin: Point = { x: 0, y: 0 };
+
+describe('Struct.getProp()', () => {
+    it('should get the value in the given property name', () => {
+        assert.equal(getProp('x', origin), 0);
+    });
+});
+
+describe('Struct.getPropC()', () => {
+    it('should get the value in the given property name', () => {
+        assert.equal(getPropC<Point, 'x'>('x')(origin), 0);
+    });
+});

--- a/test/struct/modifyProp.ts
+++ b/test/struct/modifyProp.ts
@@ -1,0 +1,32 @@
+import 'mocha';
+import * as assert from 'power-assert';
+import { modifyProp, modifyPropC } from '../../src/struct';
+
+type Point = {
+    x: number;
+    y: number;
+}
+
+const origin: Point = { x: 0, y: 0 };
+
+describe('Struct.modifyProp()', () => {
+    it('should modify the value in the property with the given function', () => {
+        const point = modifyProp('x', x => x + 42, origin);
+
+        assert.equal(point.x, 42);
+    });
+});
+
+describe('Struct.modifyPropC()', () => {
+    it('should modify the value in the property with the given function', () => {
+        const point = modifyPropC<Point, 'x'>('x')(x => x + 42)(origin);
+
+        assert.equal(point.x, 42);
+    });
+
+    it('should typecheck only with the first type argument', () => {
+        const point = modifyPropC<Point>('x')(x => x + 42)(origin); // typechecks
+
+        assert.equal(point.x, 42);
+    })
+});

--- a/test/struct/setProp.ts
+++ b/test/struct/setProp.ts
@@ -1,0 +1,26 @@
+import 'mocha';
+import * as assert from 'power-assert';
+import { setProp, setPropC } from '../../src/struct';
+
+type Point = {
+    x: number;
+    y: number;
+}
+
+const origin: Point = { x: 0, y: 0 };
+
+describe('Struct.setProp()', () => {
+    it('should set the value to the property', () => {
+        const point = setProp('x', 42, origin);
+
+        assert.equal(point.x, 42);
+    });
+});
+
+describe('Struct.setPropC()', () => {
+    it('should set the value to the property', () => {
+        const point = setPropC<Point, 'x'>('x')(42)(origin);
+
+        assert.equal(point.x, 42);
+    });
+});


### PR DESCRIPTION
Added the `Struct` type, which represents an `Object` having the specific type in each property, along with the following functions:
- `getProp`
- `setProp`
- `modifyProp`