### PR TITLE
Add Dictionary.modify() function

### DIFF
--- a/src/dictionary/index.ts
+++ b/src/dictionary/index.ts
@@ -8,6 +8,7 @@ export { keys } from './keys';
 export { lookup, lookupC } from './lookup';
 export { map, mapC } from './map';
 export { mapWithKey, mapWithKeyC } from './mapWithKey';
+export { modify, modifyC } from './modify';
 export { remove, removeC } from './remove';
 export { singleton, singletonC } from './singleton';
 export { values } from './values';

--- a/src/dictionary/modify.ts
+++ b/src/dictionary/modify.ts
@@ -1,0 +1,16 @@
+import { Dictionary } from './Dictionary';
+import { insert } from './insert';
+
+export function modify<T>(key: string, f: (x: T) => T, dict: Dictionary<T>): Dictionary<T> {
+    if (!Object.prototype.hasOwnProperty.call(dict, key)) return dict;
+
+    return insert(key, f(dict[key]), dict);
+}
+
+export function modifyC<T>(key: string): (f: (x: T) => T) => (dict: Dictionary<T>) => Dictionary<T> {
+    return function (f: (x: T) => T): (dict: Dictionary<T>) => Dictionary<T> {
+        return function (dict: Dictionary<T>): Dictionary<T> {
+            return modify(key, f, dict);
+        }
+    }
+}

--- a/test/dictionary/modify.ts
+++ b/test/dictionary/modify.ts
@@ -1,0 +1,33 @@
+import 'mocha';
+import * as assert from 'power-assert';
+import { modify, modifyC } from '../../src/dictionary';
+
+describe('Dictionary.modify()', () => {
+    it('should modify the value in the given key with the given function', () => {
+        const dict = { foo: 0, bar: 42 };
+        const expected = { foo: 0, bar: 84 };
+
+        assert.deepEqual(modify('bar', n => n * 2, dict), expected);
+    });
+
+    it('should return the given dictionary itself when the key is not present in the dictionary', () => {
+        const dict = { foo: 0, bar: 42 };
+
+        assert.deepEqual(modify('baz', n => n * 2, dict), dict);
+    });
+});
+
+describe('Dictionary.modifyC()', () => {
+    it('should modify the value in the given key with the given function', () => {
+        const dict = { foo: 0, bar: 42 };
+        const expected = { foo: 0, bar: 84 };
+
+        assert.deepEqual(modifyC<number>('bar')(n => n * 2)(dict), expected);
+    });
+
+    it('should return the given dictionary itself when the key is not present in the dictionary', () => {
+        const dict = { foo: 0, bar: 42 };
+
+        assert.deepEqual(modifyC<number>('baz')(n => n * 2)(dict), dict);
+    });
+});


### PR DESCRIPTION
Added `modify()` function (along with its curried version `modifyC()`) in `Dictionary` module, which works as the following:

```typescript
const dict = { foo: 0, bar: 42 };

 // modifies the value in the given key with the given function
console.log(modify('bar', n => n * 2, dict)); // { foo: 0, bar: 84 };

// when the given key is not present in the given dictionary, just do nothing
console.log(modify('baz', n => n * 2, dict)); // { foo: 0, bar: 42 }
```