### PR TITLE
Add Endo package along with id() function

### DIFF
--- a/src/endo/Endo.ts
+++ b/src/endo/Endo.ts
@@ -1,0 +1,1 @@
+export type Endo<T> = (x: T) => T;

--- a/src/endo/id.ts
+++ b/src/endo/id.ts
@@ -1,0 +1,3 @@
+export function id<T>(x: T): T {
+    return x;
+}

--- a/src/endo/index.ts
+++ b/src/endo/index.ts
@@ -1,0 +1,2 @@
+export { Endo } from './Endo';
+export { id } from './id';

--- a/test/endo/id.ts
+++ b/test/endo/id.ts
@@ -1,0 +1,17 @@
+import 'mocha';
+import * as assert from 'power-assert';
+import { Endo, id } from '../../src/endo';
+
+describe('Endo.id()', () => {
+    it('should return the passed argument', () => {
+        const x = { foo: 42 };
+
+        assert.equal(id(x), x);
+    });
+
+    it('should behave as Endo<T>', () => {
+        function takingEndoT<T>(_: Endo<T>) {}
+
+        takingEndoT(id);
+    });
+});


### PR DESCRIPTION
Added `Endo<T>` type, which is defined as `type Endo<T> = (x: T) => T`, along with `id()` function.