### PR TITLE
Add Dictionary.hasKey()

### DIFF
--- a/src/dictionary/hasKey.ts
+++ b/src/dictionary/hasKey.ts
@@ -1,0 +1,11 @@
+import { Dictionary } from './Dictionary';
+
+export function hasKey<T, K extends string>(key: K, dict: Dictionary<T>): dict is Record<K, T> & Dictionary<T> {
+    return Object.prototype.hasOwnProperty.call(dict, key);
+}
+
+export function hasKeyC<T, K extends string>(key: K): (dict: Dictionary<T>) => dict is Record<K, T> & Dictionary<T> {
+    return function (dict: Dictionary<T>): dict is Record<K, T> & Dictionary<T> {
+        return hasKey(key, dict);
+    }
+}

--- a/src/dictionary/index.ts
+++ b/src/dictionary/index.ts
@@ -3,6 +3,7 @@ export { empty } from './empty';
 export { entries } from './entries';
 export { filter, filterC } from './filter';
 export { fromArray } from './fromArray';
+export { hasKey, hasKeyC } from './hasKey';
 export { insert, insertC } from './insert';
 export { keys } from './keys';
 export { lookup, lookupC } from './lookup';

--- a/test/dictionary/hasKey.ts
+++ b/test/dictionary/hasKey.ts
@@ -1,0 +1,48 @@
+import 'mocha';
+import * as assert from 'power-assert';
+import { empty, hasKey, hasKeyC } from '../../src/dictionary';
+import { Dictionary } from '../../src/dictionary/Dictionary';
+
+describe('Dictionary.hasKey()', () => {
+    it('should return true when the key is present in the given dictionary', () => {
+        assert.equal(hasKey('foo', { foo: 42 }), true);
+    });
+
+    it('should return false when the key is not present in the given dictionary', () => {
+        assert.equal(hasKey('foo', empty()), false);
+    });
+
+    it('should behave as a type guard', () => {
+        const dict: Dictionary<number> = { x: 0, y: 42 };
+
+        if (hasKey('x', dict)) {
+            const record: Record<'x', number> = dict; // this should typecheck
+            assert.equal(record.x, 0);
+
+            const anotherDict: Dictionary<number> = dict; // it still behaves as a dictionary
+            assert.equal(anotherDict.y, 42);
+        }
+    });
+});
+
+describe('Dictionary.hasKeyC()', () => {
+    it('should return true when the key is present in the given dictionary', () => {
+        assert.equal(hasKeyC('foo')({ foo: 42 }), true);
+    });
+
+    it('should return false when the key is not present in the given dictionary', () => {
+        assert.equal(hasKeyC('foo')(empty()), false);
+    });
+
+    it('should behave as a type guard', () => {
+        const dict: Dictionary<number> = { x: 0, y: 42 };
+
+        if (hasKeyC<number, 'x'>('x')(dict)) {
+            const record: Record<'x', number> = dict; // this should typecheck
+            assert.equal(record.x, 0);
+
+            const anotherDict: Dictionary<number> = dict; // it still behaves as a dictionary
+            assert.equal(anotherDict.y, 42);
+        }
+    });
+});


### PR DESCRIPTION
Added `hasKey()` function in dictionary module, which determines the given dictionary has the given key.
It also behaves as a type guard which ensures the given dictionary can be regarded as a `Record` type having the given key. (implemented @hiroqn's idea, thanks!)