### PR TITLE
Bump version to v0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jazz-func",
   "description": "The essential toolbox for functional programming in TypeScript",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "bugs": "https://github.com/herp-inc/jazz-func/issues",
   "contributors": [
     "hiroqn",


### PR DESCRIPTION
Bumping version to v0.3.1 as fixing the problem about missing export of `Endo` from package root.