### PR TITLE
Redefine Dictionary<T> type with mapped type

### DIFF
--- a/src/dictionary/Dictionary.ts
+++ b/src/dictionary/Dictionary.ts
@@ -1,1 +1,1 @@
-export type Dictionary<T> = { [index: string]: T };
+export type Dictionary<T> = { [_ in string]?: T };

--- a/src/dictionary/entries.ts
+++ b/src/dictionary/entries.ts
@@ -5,7 +5,7 @@ export function entries<T>(dict: Dictionary<T>): Entry<T>[] {
     const xs: Entry<T>[] = [];
 
     for (const key in dict) {
-        const x: Entry<T> = [key, dict[key]];
+        const x: Entry<T> = [key, dict[key] as T];
         xs.push(x)
     }
 

--- a/src/dictionary/filter.ts
+++ b/src/dictionary/filter.ts
@@ -4,7 +4,13 @@ import { empty } from './empty';
 export function filter<T>(f: (x: T) => boolean, dict: Dictionary<T>): Dictionary<T> {
     const newDict: Dictionary<T> = empty<T>();
 
-    for (const key in dict) if (f(dict[key])) newDict[key] = dict[key];
+    for (const key in dict) {
+        const value = dict[key] as T;
+
+        if (f(value)) {
+            newDict[key] = value;
+        }
+    }
 
     return newDict;
 }

--- a/src/dictionary/lookup.ts
+++ b/src/dictionary/lookup.ts
@@ -2,7 +2,7 @@ import { Dictionary } from './Dictionary';
 import { Nullable } from '../nullable/Nullable';
 
 export function lookup<T>(key: string, dict: Dictionary<T>): Nullable<T> {
-    return Object.prototype.hasOwnProperty.call(dict, key) ? dict[key] : null;
+    return Object.prototype.hasOwnProperty.call(dict, key) ? dict[key] as T : null;
 }
 
 export function lookupC<T>(key: string): (dict: Dictionary<T>) => Nullable<T> {

--- a/src/dictionary/modify.ts
+++ b/src/dictionary/modify.ts
@@ -1,8 +1,9 @@
 import { Dictionary } from './Dictionary';
+import { hasKey } from './hasKey';
 import { insert } from './insert';
 
 export function modify<T>(key: string, f: (x: T) => T, dict: Dictionary<T>): Dictionary<T> {
-    if (!Object.prototype.hasOwnProperty.call(dict, key)) return dict;
+    if (!hasKey(key, dict)) return dict;
 
     return insert(key, f(dict[key]), dict);
 }

--- a/src/dictionary/values.ts
+++ b/src/dictionary/values.ts
@@ -3,7 +3,7 @@ import { Dictionary } from './Dictionary';
 export function values<T>(dict: Dictionary<T>): T[] {
     const xs: T[] = [];
 
-    for (const key in dict) xs.push(dict[key]);
+    for (const key in dict) xs.push(dict[key] as T);
 
     return xs;
 }


### PR DESCRIPTION
Redefined `Dictionary<T>` with mapped type, which was defined with indexable type.
This comes with a destructive change, so minor version must be bumped up.