### PR TITLE
Support subtyping overload for Dictionary.filter()

### DIFF
--- a/src/dictionary/filter.ts
+++ b/src/dictionary/filter.ts
@@ -1,6 +1,8 @@
 import { Dictionary } from './Dictionary';
 import { empty } from './empty';
 
+export function filter<T>(f: (x: T) => boolean, dict: Dictionary<T>): Dictionary<T>;
+export function filter<S extends T, T>(f: (x: T) => x is S, dict: Dictionary<T>): Dictionary<S>;
 export function filter<T>(f: (x: T) => boolean, dict: Dictionary<T>): Dictionary<T> {
     const newDict: Dictionary<T> = empty<T>();
 
@@ -15,6 +17,8 @@ export function filter<T>(f: (x: T) => boolean, dict: Dictionary<T>): Dictionary
     return newDict;
 }
 
+export function filterC<T>(f: (x: T) => boolean): (dict: Dictionary<T>) => Dictionary<T>;
+export function filterC<S extends T, T>(f: (x: T) => x is S): (dict: Dictionary<T>) => Dictionary<S>;
 export function filterC<T>(f: (x: T) => boolean): (dict: Dictionary<T>) => Dictionary<T> {
     return function (dict: Dictionary<T>): Dictionary<T> {
         return filter(f, dict);

--- a/test/dictionary/filter.ts
+++ b/test/dictionary/filter.ts
@@ -20,11 +20,39 @@ describe('Dictionary.filter()', () => {
     it('should filter out elements', () => {
         assert.deepEqual(filter(n => n % 2 === 0, dict), expected);
     });
+
+    it('should return subtyped dictionary when passed a type predicate', () => {
+        const dict: Dictionary<number | string> = {
+            foo: 6,
+            bar: '28',
+            baz: 496
+        };
+        function isNumber(x: any): x is number {
+            return typeof x === 'number';
+        }
+        function takesNumberDictionary(_: Dictionary<number>): void {}
+
+        takesNumberDictionary(filter(isNumber, dict)); // typechecks
+    });
 });
 
 describe('Dictionary.filterC()', () => {
     it('should filter out elements', () => {
         assert.deepEqual(filterC<number>(n => n % 2 === 0)(dict), expected);
+    });
+
+    it('should return subtyped dictionary when passed a type predicate', () => {
+        const dict: Dictionary<number | string> = {
+            foo: 6,
+            bar: '28',
+            baz: 496
+        };
+        function isNumber(x: any): x is number {
+            return typeof x === 'number';
+        }
+        function takesNumberDictionary(_: Dictionary<number>): void {}
+
+        takesNumberDictionary(filterC(isNumber)(dict)); // typechecks
     });
 });
 


### PR DESCRIPTION
Added a type signature for `Dictionary.filter()`, which supports filtering with a type predicate.