### PR TITLE
Finalize alt

### DIFF
--- a/src/nullable/alt.ts
+++ b/src/nullable/alt.ts
@@ -9,3 +9,15 @@ export function alt<T, U = T>(a: Nullable<T>, b: Nullable<U>): T | U | null {
     }
     return null;
 }
+
+export function altC<T>(a: Nullable<T>): <U>(b: Nullable<U>) => T | U | null {
+    if (a === null) {
+        return function <U>(b: Nullable<U>): T | U | null {
+            return b === null ? null : b;
+        }
+    } else {
+        return function <U>(_: Nullable<U>): T | U | null {
+            return a;
+        }
+    }
+}

--- a/src/nullable/index.ts
+++ b/src/nullable/index.ts
@@ -1,3 +1,4 @@
+export { alt, altC } from './alt';
 export { isNotNull } from './isNotNull';
 export { isNull } from './isNull';
 export { Nullable } from './Nullable';

--- a/test/nullable/alt.ts
+++ b/test/nullable/alt.ts
@@ -1,6 +1,6 @@
 import 'mocha';
 import * as assert from 'power-assert';
-import { alt } from '../../src/nullable/alt';
+import { alt, altC } from '../../src/nullable/alt';
 
 describe('Nullable.alt()', () => {
     it('should return null when the both arguments are null', () => {
@@ -17,6 +17,25 @@ describe('Nullable.alt()', () => {
 
     it('should return the first argument when it is a non-null value and the second one is also non-null', () => {
         const value: number | string | null = alt(42, 'hello, world');
+        assert.deepEqual(value, 42);
+    });
+});
+
+describe('Nullable.altC()', () => {
+    it('should return null when the both arguments are null', () => {
+        assert.equal(altC(null)(null), null);
+    });
+
+    it('should return the first argument when it is a non-null value and the second one is null', () => {
+        assert.equal(altC(42)(null), 42);
+    });
+
+    it('should return the second argument when it is a non-null value and the first one is null', () => {
+        assert.equal(altC(null)(42), 42);
+    });
+
+    it('should return the first argument when it is a non-null value and the second one is also non-null', () => {
+        const value: number | string | null = altC(42)('hello, world');
         assert.deepEqual(value, 42);
     });
 });


### PR DESCRIPTION
Defined `altC()`, a curried version for `Nullable.alt()`, and exported them from `nullable` module.