### PR TITLE
Run tests with --maxWorkers=1 option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            yarn test
+            yarn test --maxWorkers=1
 
 workflows:
   version: 2


### PR DESCRIPTION
Run tests with `--maxWorkers=1` option on CircleCI to avoid the problem where jest somehow won't terminate after running all the test cases.